### PR TITLE
Declare C++17 as mandatory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ if(CYGWIN OR MINGW)
 endif()
 target_include_directories(cpplogging PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(cpplogging ${LINKLIBS} zlib)
+target_compile_features(cpplogging PUBLIC cxx_std_17)
 list(APPEND INSTALL_TARGETS cpplogging)
 list(APPEND LINKLIBS cpplogging)
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ processors (sync, async), filters, layouts (binary, hash, text) and appenders.
 * [git](https://git-scm.com)
 * [gil](https://github.com/chronoxor/gil.git)
 * [python3](https://www.python.org)
+* C++17 standard supported
 
 Optional:
 * [clang](https://clang.llvm.org)


### PR DESCRIPTION
This project is using [std::string_view](https://en.cppreference.com/w/cpp/string/basic_string_view) feature, which is from C++17, but is not declared in CMake, neither documented in the README. For who is using latest versions of GCC, clang, ... it should not be a problem, because they already support C++17 as default standard version, but old compiler should break if the standard is not declared explicitly. 