### PR TITLE
fix: RollingFileAppender always crashes

### DIFF
--- a/include/logging/appenders/rolling_file_appender.h
+++ b/include/logging/appenders/rolling_file_appender.h
@@ -140,7 +140,7 @@ private:
     Impl& impl() noexcept { return reinterpret_cast<Impl&>(_storage); }
     const Impl& impl() const noexcept { return reinterpret_cast<Impl const&>(_storage); }
 
-    static const size_t StorageSize = 544;
+    static const size_t StorageSize = 608;
     static const size_t StorageAlign = 8;
     alignas(StorageAlign) std::byte _storage[StorageSize];
 };

--- a/source/logging/appenders/rolling_file_appender.cpp
+++ b/source/logging/appenders/rolling_file_appender.cpp
@@ -1176,9 +1176,9 @@ private:
 RollingFileAppender::RollingFileAppender(const CppCommon::Path& path, TimeRollingPolicy policy, const std::string& pattern, bool archive, bool truncate, bool auto_flush, bool auto_start)
 {
     // Check implementation storage parameters
-    [[maybe_unused]] CppCommon::ValidateAlignedStorage<sizeof(Impl), alignof(Impl), StorageSize, StorageAlign> _;
-    static_assert((StorageSize >= sizeof(Impl)), "RollingFileAppender::StorageSize must be increased!");
-    static_assert(((StorageAlign % alignof(Impl)) == 0), "RollingFileAppender::StorageAlign must be adjusted!");
+    [[maybe_unused]] CppCommon::ValidateAlignedStorage<sizeof(TimePolicyImpl), alignof(TimePolicyImpl), StorageSize, StorageAlign> _;
+    static_assert((StorageSize >= sizeof(TimePolicyImpl)), "RollingFileAppender::StorageSize must be increased!");
+    static_assert(((StorageAlign % alignof(TimePolicyImpl)) == 0), "RollingFileAppender::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)TimePolicyImpl(*this, path, policy, pattern, archive, truncate, auto_flush, auto_start);
@@ -1187,9 +1187,9 @@ RollingFileAppender::RollingFileAppender(const CppCommon::Path& path, TimeRollin
 RollingFileAppender::RollingFileAppender(const CppCommon::Path& path, const std::string& filename, const std::string& extension, size_t size, size_t backups, bool archive, bool truncate, bool auto_flush, bool auto_start)
 {
     // Check implementation storage parameters
-    [[maybe_unused]] CppCommon::ValidateAlignedStorage<sizeof(Impl), alignof(Impl), StorageSize, StorageAlign> _;
-    static_assert((StorageSize >= sizeof(Impl)), "RollingFileAppender::StorageSize must be increased!");
-    static_assert(((StorageAlign % alignof(Impl)) == 0), "RollingFileAppender::StorageAlign must be adjusted!");
+    [[maybe_unused]] CppCommon::ValidateAlignedStorage<sizeof(SizePolicyImpl), alignof(SizePolicyImpl), StorageSize, StorageAlign> _;
+    static_assert((StorageSize >= sizeof(SizePolicyImpl)), "RollingFileAppender::StorageSize must be increased!");
+    static_assert(((StorageAlign % alignof(SizePolicyImpl)) == 0), "RollingFileAppender::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)SizePolicyImpl(*this, path, filename, extension, size, backups, archive, truncate, auto_flush, auto_start);


### PR DESCRIPTION
RollingFileAppender always crashes after fixing https://github.com/chronoxor/CppCommon/commit/819348e9d39866e0c8a3ac599da635dc77cd57de, RollingFileAppender::StorageSize is not enough

sizeof(TimePolicyImpl)==608
sizeof(SizePolicyImpl)==600
![image](https://github.com/chronoxor/CppLogging/assets/5846696/df8234a5-0f4e-4b66-9fcd-17d9411dadda)